### PR TITLE
Add GHA CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: build
+on:
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
+  pull_request:
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest,macos-latest]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Pre-reqs (apt)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get -y update && sudo apt-get install build-essential \
+            libpng-dev zlib1g-dev libx11-dev libxaw7-dev libxt-dev x11proto-core-dev libgif-dev
+      - name: Pre-reqs (homebrew)
+        if: runner.os == 'macOS'
+        run: |
+          brew reinstall gfortran
+          brew install automake \
+            libpng \
+            libxt
+      - name: Bootstrap
+        shell: bash
+        run: |
+          sh ./bootstrap
+      - name: Configure
+        shell: bash
+        run: |
+          sh ./configure
+      - name: Make
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          make
+      - name: Make
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          make LDFLAGS="$(pkg-config --libs --static libpng xt)"


### PR DESCRIPTION
This is an initial CI workflow for Linux and macOS.

Of note, the dependencies on macOS here are provided using Homebrew and as such
the `INC`/`LIB` paths are not in their standard locations. The correct approach
is to have autoconf use `pkg-config`. I have worked around this for now by
setting `LDFLAGS` myself.

Build logs for this PR are here: <https://github.com/zmughal/pgplot-autotool/actions/runs/1376910175>.