### PR TITLE
Use pkg-config to get x11 and xt flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,12 @@ jobs:
             echo "LIBRARY_PATH=$(brew --prefix)/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}" >> $GITHUB_ENV
           else
             echo "Unlinking libraries from Homebrew prefix so that pkg-config must be used."
-            brew unlink \
-              libpng \
-              libxt libice libsm libx11
+            FORMULAE_TO_UNLINK="libpng libxt libice libsm libx11"
+            brew unlink $FORMULAE_TO_UNLINK
+            PKG_CONFIG_PATH_FOR_FORMULAE=$( brew ls $FORMULAE_TO_UNLINK \
+              | grep /pkgconfig/ | xargs -n1 dirname \
+              | sort -u | tr '\n' ':' | sed 's/:$//' )
+            echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH_FOR_FORMULAE${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" >> $GITHUB_ENV
           fi
       - name: Bootstrap
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,12 @@ jobs:
         # - false: automatically configure X11
         # - true: disable building with X11 (use --without-x option)
         without-x: [false,true]
+        # used for macos runner
+        homebrew-unlink: [ false ]
+        include:
+          - os: macos-latest
+            without-x: false
+            homebrew-unlink: true
     steps:
       - uses: actions/checkout@v2
       - name: Pre-reqs (apt)
@@ -30,7 +36,18 @@ jobs:
           brew install automake \
             libpng \
             libxt
-          echo "LIBRARY_PATH=$(brew --prefix)/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}" >> $GITHUB_ENV
+      - name: Prepare for linking with Homebrew
+        if: runner.os == 'macOS'
+        run: |
+          if ! ${{ matrix.homebrew-unlink }}; then
+            echo "Using Homebrew prefix /usr/local/lib for linking via LIBRARY_PATH in order to keep the default search path."
+            echo "LIBRARY_PATH=$(brew --prefix)/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}" >> $GITHUB_ENV
+          else
+            echo "Unlinking libraries from Homebrew prefix so that pkg-config must be used."
+            brew unlink \
+              libpng \
+              libxt libice libsm libx11
+          fi
       - name: Bootstrap
         run: |
           sh ./bootstrap

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,6 @@ jobs:
       - name: Make
         run: |
           make
+      - name: Show pkg-config files
+        run: |
+          head -n100 *.pc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,5 @@ jobs:
         run: |
           sh ./configure
       - name: Make
-        if: runner.os == 'Linux'
         run: |
           make
-      - name: Make
-        if: runner.os == 'macOS'
-        run: |
-          make LDFLAGS="$(pkg-config --libs --static libpng xt)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest,macos-latest]
+        # without-x:
+        # - false: automatically configure X11
+        # - true: disable building with X11 (use --without-x option)
+        without-x: [false,true]
     steps:
       - uses: actions/checkout@v2
       - name: Pre-reqs (apt)
@@ -30,8 +34,9 @@ jobs:
         run: |
           sh ./bootstrap
       - name: Configure
-        run: |
+        run:
           sh ./configure
+            ${{ fromJSON('[ "", "--without-x" ]')[ matrix.without-x ] }}
       - name: Make
         run: |
           make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           brew install automake \
             libpng \
             libxt
+          echo "LIBRARY_PATH=$(brew --prefix)/lib${LIBRARY_PATH:+:${LIBRARY_PATH}}" >> $GITHUB_ENV
       - name: Bootstrap
         run: |
           sh ./bootstrap

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pgplot_link_adam
 .libs
 *.la
 *.lo
+*.o
 Makefile
 Makefile.in
 acinclude.m4

--- a/configure.ac
+++ b/configure.ac
@@ -119,6 +119,9 @@ AS_IF([ test "x$with_x" != xno -a "x$no_x" != x ],
                CPPFLAGS="$CPPFLAGS $X11_CFLAGS"
               ]
            )
+          ],
+          [
+           dnl no x11 via pkg-config either
           ]
        )
       ]

--- a/configure.ac
+++ b/configure.ac
@@ -75,12 +75,13 @@ drivers="exdriv.lo pgdriv.lo cadriv.lo hgdriv.lo lxdriv.lo  vtdriv.lo hidriv.lo 
 dnl   Not all platforms have X
 have_x11=no
 have_xt=no
-AS_IF([ test "x$no_x" = "x"],
+AS_IF([ test "$with_x" != no ],
       [
        PKG_CHECK_MODULES(
           [X11],
           [x11],
           [have_x11=yes
+           no_x=""
            PKG_CONFIG_REQUIRES="${PKG_CONFIG_REQUIRES}[,]x11"
            PKG_CHECK_MODULES(
               [XT],

--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,22 @@ drivers="exdriv.lo pgdriv.lo cadriv.lo hgdriv.lo lxdriv.lo  vtdriv.lo hidriv.lo 
 dnl   Not all platforms have X
 have_x11=no
 have_xt=no
-AS_IF([ test "$with_x" != no ],
+dnl	+--------+------------------------+----------+----------+--------+-----+
+dnl	|Variable|      AC_PATH_XTRA      |-without-x|-with-x=no|-with-x | --x |
+dnl	+--------+------------+-----------+----------+----------+--------+-----+
+dnl	|        |  success   |  failure  |          |          |        |     |
+dnl	+--------+------------+-----------+----------+----------+--------+-----+
+dnl	|  no_x  |     ''     |   'yes'   |  'yes'   |          |        |     |
+dnl	+--------+------------+-----------+----------+----------+--------+-----+
+dnl	| with_x |            |           |   'no'   |   'no'   | 'yes'  |'yes'|
+dnl	+--------+------------+-----------+----------+----------+--------+-----+
+dnl	Notes:
+dnl     1) AC_PATH_XTRA runs first and modifies no_x in the presence of -without-x
+dnl     2) If --with-x is not specified, AC_PATH_XTRA assumes with_x='yes'
+dnl
+dnl     Check pkg-config if the user did not forbid X and AC_PATH_XTRA failed to find it
+AS_IF([ test "x$with_x" != xno -a "x$no_x" != x ],
+
       [
        PKG_CHECK_MODULES(
           [X11],

--- a/configure.ac
+++ b/configure.ac
@@ -82,10 +82,6 @@ AS_IF([ test "x$no_x" = "x"],
           [x11],
           [have_x11=yes
            PKG_CONFIG_REQUIRES="${PKG_CONFIG_REQUIRES}[,]x11"
-           X_LIBS="$X_LIBS $X11_LIBS"
-           LIBS="$LIBS $X11_LIBS"
-           X_CFLAGS="$X_CFLAGS $X11_CFLAGS"
-           CPPFLAGS="$CPPFLAGS $X11_CFLAGS"
            PKG_CHECK_MODULES(
               [XT],
               dnl have sm and ice listed here so that contents of $X_PRE_LIBS
@@ -93,10 +89,18 @@ AS_IF([ test "x$no_x" = "x"],
               [sm ice xt],
               [have_xt=yes
                PKG_CONFIG_REQUIRES="${PKG_CONFIG_REQUIRES}[,]xt"
+               dnl XT_* has xt + x11 because xt depends on x11
                X_LIBS="$X_LIBS $XT_LIBS"
                LIBS="$LIBS $XT_LIBS"
                X_CFLAGS="$X_CFLAGS $XT_CFLAGS"
                CPPFLAGS="$CPPFLAGS $XT_CFLAGS"
+              ],
+              [
+               dnl only have x11
+               X_LIBS="$X_LIBS $X11_LIBS"
+               LIBS="$LIBS $X11_LIBS"
+               X_CFLAGS="$X_CFLAGS $X11_CFLAGS"
+               CPPFLAGS="$CPPFLAGS $X11_CFLAGS"
               ]
            )
           ]

--- a/configure.ac
+++ b/configure.ac
@@ -88,7 +88,9 @@ AS_IF([ test "x$no_x" = "x"],
            CPPFLAGS="$CPPFLAGS $X11_CFLAGS"
            PKG_CHECK_MODULES(
               [XT],
-              [xt],
+              dnl have sm and ice listed here so that contents of $X_PRE_LIBS
+              dnl can be found
+              [sm ice xt],
               [have_xt=yes
                PKG_CONFIG_REQUIRES="${PKG_CONFIG_REQUIRES}[,]xt"
                X_LIBS="$X_LIBS $XT_LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -73,6 +73,35 @@ dnl   automatically (see the automake manual's FAQ for justification).
 drivers="exdriv.lo pgdriv.lo cadriv.lo hgdriv.lo lxdriv.lo  vtdriv.lo hidriv.lo psdriv.lo ttdriv.lo cwdriv.lo gldriv.lo nedriv.lo hpdriv.lo lsdriv.lo nudriv.lo qmdriv.lo vadriv.lo cgdriv.lo nexsup.lo rvdriv.lo xmdriv.lo tkdriv.lo pkdriv.lo xadriv.lo"
 
 dnl   Not all platforms have X
+have_x11=no
+have_xt=no
+AS_IF([ test "x$no_x" = "x"],
+      [
+       PKG_CHECK_MODULES(
+          [X11],
+          [x11],
+          [have_x11=yes
+           PKG_CONFIG_REQUIRES="${PKG_CONFIG_REQUIRES}[,]x11"
+           X_LIBS="$X_LIBS $X11_LIBS"
+           LIBS="$LIBS $X11_LIBS"
+           X_CFLAGS="$X_CFLAGS $X11_CFLAGS"
+           CPPFLAGS="$CPPFLAGS $X11_CFLAGS"
+           PKG_CHECK_MODULES(
+              [XT],
+              [xt],
+              [have_xt=yes
+               PKG_CONFIG_REQUIRES="${PKG_CONFIG_REQUIRES}[,]xt"
+               X_LIBS="$X_LIBS $XT_LIBS"
+               LIBS="$LIBS $XT_LIBS"
+               X_CFLAGS="$X_CFLAGS $XT_CFLAGS"
+               CPPFLAGS="$CPPFLAGS $XT_CFLAGS"
+              ]
+           )
+          ]
+       )
+      ]
+)
+
 COMPILE_PGDISP=no
 AS_IF([ test "x$no_x" = "x"],
       [


### PR DESCRIPTION
This PR is on top of the commits of <https://github.com/djerius/pgplot-autotool/pull/2>.

As discussed in <https://github.com/djerius/pgplot-autotool/pull/2>, some
package managers (e.g., Homebrew) do not place x11 and xt files in the standard
locations. This uses `pkg-config` to get that information first.
