### PR TITLE
GHA: Add MSYS2 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,33 @@ jobs:
       - name: Show pkg-config files
         run: |
           head -n100 *.pc
+  ci-msys2:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+    defaults:
+      run:
+        shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up build
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            base-devel
+            autotools
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-libpng
+      - name: Bootstrap
+        run: |
+          sh ./bootstrap
+      - name: Configure
+        run: |
+          sh ./configure
+      - name: Make
+        run: |
+          make
+      - name: Show pkg-config files
+        run: |
+          head -n100 *.pc

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,9 @@ AC_CHECK_LIB(m, sincos)
 dnl     Checks for header files.
 AC_HEADER_STDC
 AC_PATH_XTRA
-AC_CHECK_HEADERS([fcntl.h limits.h memory.h netdb.h netinet/in.h stddef.h sys/file.h sys/socket.h sys/systeminfo.h sys/time.h termios.h unistd.h values.h])
+AC_CHECK_HEADERS([fcntl.h limits.h memory.h netdb.h netinet/in.h stddef.h sys/file.h sys/socket.h sys/systeminfo.h sys/time.h unistd.h values.h])
+
+AC_SYS_POSIX_TERMIOS
 
 dnl    get the flags required to link other languages against fortran
 dnl    using their compilers, not fortran
@@ -70,7 +72,7 @@ dnl   These are the driver files that will actually be built.
 dnl   In true autoconf style, we do not attempt to generate this list
 dnl   automatically (see the automake manual's FAQ for justification).
 
-drivers="exdriv.lo pgdriv.lo cadriv.lo hgdriv.lo lxdriv.lo  vtdriv.lo hidriv.lo psdriv.lo ttdriv.lo cwdriv.lo gldriv.lo nedriv.lo hpdriv.lo lsdriv.lo nudriv.lo qmdriv.lo vadriv.lo cgdriv.lo nexsup.lo rvdriv.lo xmdriv.lo tkdriv.lo pkdriv.lo xadriv.lo"
+drivers="exdriv.lo pgdriv.lo cadriv.lo hgdriv.lo lxdriv.lo  hidriv.lo psdriv.lo cwdriv.lo gldriv.lo hpdriv.lo lsdriv.lo nudriv.lo qmdriv.lo vadriv.lo cgdriv.lo rvdriv.lo xmdriv.lo tkdriv.lo pkdriv.lo xadriv.lo"
 
 dnl   Not all platforms have X
 have_x11=no
@@ -197,6 +199,24 @@ AS_IF([test "$mst_prog_gnu_f77_version" != '0.0.0' && test "$mst_prog_gnu_f77_ve
 AC_SUBST([PKG_CONFIG_LIBS])
 AC_SUBST([PKG_CONFIG_CFLAGS])
 
+dnl   drivers ttdriv and vtdriv require termios; only include them if
+dnl   it's available.
+
+AM_CONDITIONAL([HAVE_TERMIOS], [test "$ac_cv_sys_posix_termios" = "yes" ])
+
+AS_IF( [test "$ac_cv_sys_posix_termios" = "yes" ],
+       [
+         drivers="$drivers ttdriv.lo vtdriv.lo"
+       ]
+)
+
+dnl   drivers nexup and nedriv require sys/socket.h
+AS_IF([test "$ac_cv_header_sys_socket_h" = "yes"],
+      [
+         drivers="$drivers nexsup.lo nedriv.lo"
+      ]
+)
+
 
 
 dnl   Add the png driver if the PNG header and library are available.
@@ -239,6 +259,8 @@ AS_IF([test $have_png = yes],
 	CPPFLAGS="$CPPFLAGS $PNG_CFLAGS"
       ]
 )
+
+
 
 
 dnl   clean up pkg-config requires line

--- a/drivers/Makefile.am
+++ b/drivers/Makefile.am
@@ -31,9 +31,9 @@ grexec.f: $(BUILT_DRIVER_ROUTINES) makegrexec.pl
 # These are all the driver routines, even if they do not build
 
 DRIVER_ROUTINES = exdriv.f pgdriv.f cadriv.f hgdriv.f lxdriv.f		\
-ppdriv.f.in vtdriv.f gidriv.f hidriv.f psdriv.f ttdriv.f cwdriv.f	\
-gldriv.f nedriv.f wddriv.f.in hpdriv.f lsdriv.f nudriv.f qmdriv.f	\
-vadriv.f cgdriv.c nexsup.c rvdriv.c x2driv.c xmdriv.c figdisp_comm.c	\
+ppdriv.f.in gidriv.f hidriv.f psdriv.f cwdriv.f	\
+gldriv.f wddriv.f.in hpdriv.f lsdriv.f nudriv.f qmdriv.f	\
+vadriv.f cgdriv.c rvdriv.c x2driv.c xmdriv.c figdisp_comm.c	\
 pgxwin.c pndriv.c tkdriv.c xadriv.c xwdriv.c bcdriv.f gvdriv.f		\
 ladriv.f lvdriv.f tfdriv.f xedriv.f gcdriv.f todriv.f zedriv.f		\
 ccdriv.f ljdriv.f lhdriv.f mfdriv.f hjdriv.f lndriv.f pxdriv.f		\

--- a/fonts/Makefile.am
+++ b/fonts/Makefile.am
@@ -10,9 +10,9 @@ pgpack_SOURCES = pgpack.f
 
 pkg_libexecdir = $(libexecdir)/$(PACKAGE)
 
-grfont.dat: grfont.txt pgpack
+grfont.dat: grfont.txt pgpack$(EXEEXT)
 	-rm -f grfont.dat
-	./pgpack < $(srcdir)/grfont.txt
+	./pgpack$(EXEEXT) < $(srcdir)/grfont.txt
 
 install-exec-hook : grfont.dat
 	$(MKDIR_P) $(DESTDIR)$(pkg_libexecdir)

--- a/sys/Makefile.am
+++ b/sys/Makefile.am
@@ -20,7 +20,11 @@ F_ROUTINES = grflun.f grgenv.f grglun.f grgmsg.f grlgtr.f \
 	     groptx.f grsy00.f grtrml.f grtter.f
 
 
-C_ROUTINES = grdate.c  grfileio.c  grgetc.c  grgmem.c  grtermio.c  gruser.c
+C_ROUTINES = grdate.c  grfileio.c  grgmem.c  gruser.c
+
+if HAVE_TERMIOS
+C_ROUTINES += grgetc.c grtermio.c
+endif
 
 AM_CFLAGS = -DPG_PPU
 


### PR DESCRIPTION
This PR is on top of the commits of
<https://github.com/djerius/pgplot-autotool/pull/2> and
<https://github.com/djerius/pgplot-autotool/pull/3>.

This PR also requires
- disabling some of the routines in `sys/` and some of the drivers in
  `drivers/` because of required headers that are not available under MinGW:
    * require `termios.h`: `sys/grgetc.c`, `sys/grtermio.c`,
      `drivers/ttdriv.f`, `drivers/vtdriv.f`
    * require `sys/socket.h`: `drivers/nexsup.c`, `drivers/nedriv.f`
- setting `FC` to `gfortran` because `f77` is not available (on Linux `f77` is
  a symlink to `gfortran`)
    * `FC = f77` means `fonts/pgpack` can not build
    * this can be worked around by setting `FC` to the contents of `F77` (`gfortran`)
